### PR TITLE
feat: add wiki submodule for project documentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wiki"]
+	path = wiki
+	url = https://github.com/KaSaNaa/Script-Scheduler-Engine.wiki.git


### PR DESCRIPTION
This pull request includes the addition of a new submodule for the wiki in the repository. The most important changes are:

Submodule addition:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R3): Added a new submodule configuration for the wiki, specifying the path and URL of the submodule.
* [`wiki`](diffhunk://#diff-12a435ec8454c6d1c90a1d92812b09af11bee711fbe524d56a8f26ea7c5ccee8R1): Added the subproject commit reference for the newly added wiki submodule.